### PR TITLE
200 nanoseconds is not enough

### DIFF
--- a/chapter4/safely_example.go
+++ b/chapter4/safely_example.go
@@ -14,5 +14,5 @@ func message() {
 func main() {
 	safely.Go(message)
 	println("Outside goroutine")
-	time.Sleep(200)
+	time.Sleep(time.Millisecond * 1)
 }


### PR DESCRIPTION
I'm using go 1.11.2 and 200 nanoseconds is not enough to print the message function message.
Increasing it to 1 millisecond should be enough time for the print of message function and for the safely's log print